### PR TITLE
Cloudlab profile debug

### DIFF
--- a/setup-driver.sh
+++ b/setup-driver.sh
@@ -1,11 +1,5 @@
 #!/bin/sh
 
-## bash users
-for user in $(ls /users)
-do
-	sudo chsh $user --shell /bin/bash
-done
-
 set -x
 
 DIRNAME=`dirname $0`

--- a/setup-driver.sh
+++ b/setup-driver.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+## bash users
+for user in $(ls /users)
+do
+	sudo chsh $user --shell /bin/bash
+done
+
 set -x
 
 DIRNAME=`dirname $0`

--- a/setup-pythia-compute.sh
+++ b/setup-pythia-compute.sh
@@ -70,18 +70,18 @@ service_start redis
 maybe_install_packages python3-pip
 
 # Bring back rustup for compilation error
-su emreates -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
+su toslali -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
 source $HOME/.cargo/env
 rustup update stable
 echo "**** Mert updating rust for match compile error ***"
 
 
-chown emreates -R /local/reconstruction
-su emreates -c "cargo update --manifest-path /local/reconstruction/Cargo.toml -p lexical-core"
-su emreates -c "cargo update --manifest-path /local/reconstruction/pythia_server/Cargo.toml -p lexical-core"
-su emreates -c "cargo install --locked --path /local/reconstruction"
-su emreates -c "cargo install --locked --path /local/reconstruction/pythia_server"
-sudo ln -s /users/emreates/.cargo/bin/pythia_server /usr/local/bin/
+chown toslali -R /local/reconstruction
+su toslali -c "cargo update --manifest-path /local/reconstruction/Cargo.toml -p lexical-core"
+su toslali -c "cargo update --manifest-path /local/reconstruction/pythia_server/Cargo.toml -p lexical-core"
+su toslali -c "cargo install --locked --path /local/reconstruction"
+su toslali -c "cargo install --locked --path /local/reconstruction/pythia_server"
+sudo ln -s /users/toslali/.cargo/bin/pythia_server /usr/local/bin/
 
 echo -e 'nova\tALL=(ALL)\tNOPASSWD: ALL' >> /etc/sudoers
 
@@ -133,6 +133,6 @@ sudo systemctl start pythia.service
 
 touch $OURDIR/setup-pythia-compute-done
 logtend "pythia-compute"
-chown emreates -R /local
-su emreates -c 'cd /local/dotfiles; ./setup_cloudlab.sh'
+chown toslali -R /local
+su toslali -c 'cd /local/dotfiles; ./setup_cloudlab.sh'
 exit 0

--- a/setup-pythia-compute.sh
+++ b/setup-pythia-compute.sh
@@ -56,7 +56,7 @@ do
     cd /local/$repo
     GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i /local/.ssh/$repo" git fetch --all
     git checkout $(git status | head -n 1 | awk '{print $3}') -f
-    GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i /local/.ssh/reconstruction" git switch cloudlab-debug
+    GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i /local/.ssh/reconstruction" git checkout --track origin/cloudlab-debug
     GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i /local/.ssh/$repo" git pull
     cd /local
 done

--- a/setup-pythia-compute.sh
+++ b/setup-pythia-compute.sh
@@ -56,6 +56,7 @@ do
     cd /local/$repo
     GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i /local/.ssh/$repo" git fetch --all
     git checkout $(git status | head -n 1 | awk '{print $3}') -f
+    GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i /local/.ssh/reconstruction" git switch cloudlab-debug
     GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i /local/.ssh/$repo" git pull
     cd /local
 done
@@ -76,8 +77,10 @@ echo "**** Mert updating rust for match compile error ***"
 
 
 chown emreates -R /local/reconstruction
+su emreates -c "cargo update --manifest-path /local/reconstruction/Cargo.toml -p lexical-core"
+su emreates -c "cargo update --manifest-path /local/reconstruction/pythia_server/Cargo.toml -p lexical-core"
 su emreates -c "cargo install --locked --path /local/reconstruction"
-su emreates -c "cargo install --path /local/reconstruction/pythia_server"
+su emreates -c "cargo install --locked --path /local/reconstruction/pythia_server"
 sudo ln -s /users/emreates/.cargo/bin/pythia_server /usr/local/bin/
 
 echo -e 'nova\tALL=(ALL)\tNOPASSWD: ALL' >> /etc/sudoers

--- a/setup-pythia.sh
+++ b/setup-pythia.sh
@@ -86,8 +86,10 @@ echo "**** Mert updating rust for match compile error ***"
 
 
 chown emreates -R /local/reconstruction
+su emreates -c "cargo update --manifest-path /local/reconstruction/Cargo.toml -p lexical-core"
+su emreates -c "cargo update --manifest-path /local/reconstruction/pythia_server/Cargo.toml -p lexical-core"
 su emreates -c "cargo install --locked --path /local/reconstruction"
-su emreates -c "cargo install --path /local/reconstruction/pythia_server"
+su emreates -c "cargo install --locked --path /local/reconstruction/pythia_server"
 sudo ln -s /users/emreates/.cargo/bin/pythia_server /usr/local/bin/
 
 mkdir -p /opt/stack/manifest

--- a/setup-pythia.sh
+++ b/setup-pythia.sh
@@ -80,18 +80,18 @@ $PSSH -v $PHOSTS -o $OURDIR/pssh.setup-pythia.stdout \
 maybe_install_packages python3-pip
 
 # Bring back rustup for compilation error
-su emreates -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
+su toslali -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
 source $HOME/.cargo/env
 rustup update stable
 echo "**** Mert updating rust for match compile error ***"
 
 
-chown emreates -R /local/reconstruction
-su emreates -c "cargo update --manifest-path /local/reconstruction/Cargo.toml -p lexical-core"
-su emreates -c "cargo update --manifest-path /local/reconstruction/pythia_server/Cargo.toml -p lexical-core"
-su emreates -c "cargo install --locked --path /local/reconstruction"
-su emreates -c "cargo install --locked --path /local/reconstruction/pythia_server"
-sudo ln -s /users/emreates/.cargo/bin/pythia_server /usr/local/bin/
+chown toslali -R /local/reconstruction
+su toslali -c "cargo update --manifest-path /local/reconstruction/Cargo.toml -p lexical-core"
+su toslali -c "cargo update --manifest-path /local/reconstruction/pythia_server/Cargo.toml -p lexical-core"
+su toslali -c "cargo install --locked --path /local/reconstruction"
+su toslali -c "cargo install --locked --path /local/reconstruction/pythia_server"
+sudo ln -s /users/toslali/.cargo/bin/pythia_server /usr/local/bin/
 
 mkdir -p /opt/stack/manifest
 chmod -R g+rwX /opt/
@@ -205,6 +205,6 @@ sudo systemctl start pythia.service
 
 touch $OURDIR/setup-pythia-done
 logtend "pythia"
-chown emreates -R /local
-su emreates -c 'cd /local/dotfiles; ./setup_cloudlab.sh'
+chown toslali -R /local
+su toslali -c 'cd /local/dotfiles; ./setup_cloudlab.sh'
 exit 0

--- a/setup-pythia.sh
+++ b/setup-pythia.sh
@@ -60,7 +60,7 @@ do
     cd /local/$repo
     GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i /local/.ssh/$repo" git fetch --all
     git checkout $(git status | head -n 1 | awk '{print $3}') -f
-    GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i /local/.ssh/reconstruction" git switch cloudlab-debug
+    GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i /local/.ssh/reconstruction" git checkout --track origin/cloudlab-debug
     GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i /local/.ssh/$repo" git pull
     cd /local
 done

--- a/setup-pythia.sh
+++ b/setup-pythia.sh
@@ -60,6 +60,7 @@ do
     cd /local/$repo
     GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i /local/.ssh/$repo" git fetch --all
     git checkout $(git status | head -n 1 | awk '{print $3}') -f
+    GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i /local/.ssh/reconstruction" git switch cloudlab-debug
     GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i /local/.ssh/$repo" git pull
     cd /local
 done


### PR DESCRIPTION
Fixed cloudlab profile, follows [Mert's instruction](https://docc-lab.slack.com/archives/CC644J8RM/p1663786701973459)

**List of things done:**
- **In commits**
  - Reset git directly to a4c2fa1646a790df9ee48926348532ef7f3e706d where everything was working
- **In bash script (for both ctl and cp nodes)**
  - Add bash env setting for every user in the organization.
  - Add `cargo update` for lexcial-core

**About review**
- Please disregard 2b465cd446f655f2802c694c48cdcf837a079f61 and b202a225644ad3e12723acbfcadcde8ab61c04eb. They're for debugging purposes only.
  - I will remove them once PR is approved.
- Please follow [my instruction](https://docc-lab.slack.com/archives/CC644J8RM/p1664245875017359?thread_ts=1663786701.973459&cid=CC644J8RM )
- Commits in this PR are cooperating with https://github.com/docc-lab/reconstruction/pull/6, which should be tested together via cloudlab profile.