### PR TITLE
Org-wise permission removal

### DIFF
--- a/osp.py
+++ b/osp.py
@@ -40,10 +40,10 @@ pc.defineParameter("release","OpenStack Release",
 pc.defineParameter("computeNodeCount", "Number of compute nodes (at Site 1)",
                    portal.ParameterType.INTEGER, 1)
 pc.defineParameter("controllerDiskImage","Controller Node Disk Image",
-                   portal.ParameterType.IMAGE,"",
+                   portal.ParameterType.IMAGE,"urn:publicid:IDN+lab.onelab.eu+image+tracing-pythia-PG0:base-with-repos",
                    longDescription="An image URN or URL that the controller node will run.")
 pc.defineParameter("computeDiskImage","Compute Node Disk Image",
-                   portal.ParameterType.IMAGE,"",
+                   portal.ParameterType.IMAGE,"urn:publicid:IDN+lab.onelab.eu+image+tracing-pythia-PG0:base-with-repos",
                    longDescription="An image URN or URL that the compute node will run.")
 pc.defineParameter("networkManagerDiskImage","Network Manager Node Disk Image",
                    portal.ParameterType.IMAGE,"",
@@ -60,25 +60,25 @@ pc.defineParameter("ml2plugin","ML2 Plugin",
                    [("openvswitch","OpenVSwitch"),
                     ("linuxbridge","Linux Bridge")],
                    longDescription="Starting in Liberty and onwards, we support both the OpenVSwitch and LinuxBridge ML2 plugins to create virtual networks in Neutron.  OpenVSwitch remains our default and best-supported option.  Note: you cannot use GRE tunnels with the LinuxBridge driver; you'll need to use VXLAN tunnels instead.  And by default, the profile allocates 1 GRE tunnel -- so you must change that immediately, or you will see an error.")
-pc.defineParameter("extraImageURLs","Extra VM Image URLs",
-                   portal.ParameterType.STRING,"",
-                   longDescription="This parameter allows you to specify a space-separated list of URLs, each of which points to an OpenStack VM image, which we will download and slighty tweak before uploading to Glance in your OpenStack experiment.")
+# pc.defineParameter("extraImageURLs","Extra VM Image URLs",
+#                    portal.ParameterType.STRING,"",
+#                    longDescription="This parameter allows you to specify a space-separated list of URLs, each of which points to an OpenStack VM image, which we will download and slighty tweak before uploading to Glance in your OpenStack experiment.")
 pc.defineParameter("firewall","Experiment Firewall",
                    portal.ParameterType.BOOLEAN,False,
                    longDescription="Optionally add a CloudLab infrastructure firewall between the public IP addresses of your nodes (and your floating IPs) and the Internet (and rest of CloudLab).")
 
-pc.defineParameter("ubuntuMirrorHost","Ubuntu Package Mirror Hostname",
-                   portal.ParameterType.STRING,"",advanced=True,
-                   longDescription="A specific Ubuntu package mirror host to use instead of us.archive.ubuntu.com (mirror must have Ubuntu in top-level dir, or you must also edit the mirror path parameter below)")
-pc.defineParameter("ubuntuMirrorPath","Ubuntu Package Mirror Path",
-                   portal.ParameterType.STRING,"",advanced=True,
-                   longDescription="A specific Ubuntu package mirror path to use instead of /ubuntu/ (you must also set a value for the package mirror parameter)")
-pc.defineParameter("doAptUpgrade","Upgrade OpenStack packages and dependencies to the latest versions",
-                   portal.ParameterType.BOOLEAN, False,advanced=True,
-                   longDescription="The default images this profile uses have OpenStack and dependent packages preloaded.  To guarantee that these scripts always work, we no longer upgrade to the latest packages by default, to avoid changes.  If you want to ensure you have the latest packages, you should enable this option -- but if there are setup failures, we can't guarantee support.  NOTE: selecting this option requires that you also select the option to update the Apt package cache!")
-pc.defineParameter("doAptDistUpgrade","Upgrade all packages to their latest versions",
-                   portal.ParameterType.BOOLEAN, False,advanced=True,
-                   longDescription="Sometimes, if you install using the fromScratch option, you'll need to update some of the base distro packages via apt-get dist-upgrade; this option handles that.  NOTE: selecting this option requires that you also select the option to update the Apt package cache!")
+# pc.defineParameter("ubuntuMirrorHost","Ubuntu Package Mirror Hostname",
+#                    portal.ParameterType.STRING,"",advanced=True,
+#                    longDescription="A specific Ubuntu package mirror host to use instead of us.archive.ubuntu.com (mirror must have Ubuntu in top-level dir, or you must also edit the mirror path parameter below)")
+# pc.defineParameter("ubuntuMirrorPath","Ubuntu Package Mirror Path",
+#                    portal.ParameterType.STRING,"",advanced=True,
+#                    longDescription="A specific Ubuntu package mirror path to use instead of /ubuntu/ (you must also set a value for the package mirror parameter)")
+# pc.defineParameter("doAptUpgrade","Upgrade OpenStack packages and dependencies to the latest versions",
+#                    portal.ParameterType.BOOLEAN, False,advanced=True,
+#                    longDescription="The default images this profile uses have OpenStack and dependent packages preloaded.  To guarantee that these scripts always work, we no longer upgrade to the latest packages by default, to avoid changes.  If you want to ensure you have the latest packages, you should enable this option -- but if there are setup failures, we can't guarantee support.  NOTE: selecting this option requires that you also select the option to update the Apt package cache!")
+# pc.defineParameter("doAptDistUpgrade","Upgrade all packages to their latest versions",
+#                    portal.ParameterType.BOOLEAN, False,advanced=True,
+#                    longDescription="Sometimes, if you install using the fromScratch option, you'll need to update some of the base distro packages via apt-get dist-upgrade; this option handles that.  NOTE: selecting this option requires that you also select the option to update the Apt package cache!")
 pc.defineParameter("doCloudArchiveStaging","Enable Ubuntu Cloud Archive staging repo",
                    portal.ParameterType.BOOLEAN, False,advanced=True,
                    longDescription="If the base Ubuntu version is an LTS release, we enable package installation from the Ubuntu Cloud Archive.  If you want the latest packages, you must enable the staging repository.  This option does that.  Of course, it only matters if you have selected either a fromScratch install, or if you have selected the option to upgrade installed packages.")
@@ -141,7 +141,7 @@ pc.defineParameter("osNodeTypeSite2", "Site 2 Hardware Type",
                    advanced=True)
 
 pc.defineParameter("resizeRoot","Resize Root Filesystem",
-                   portal.ParameterType.STRING,"",advanced=True,
+                   portal.ParameterType.STRING,"50",advanced=True,
                    longDescription="If set to 0 or integer, this will expand your root filesystem on each node.  In order to make the expansion possible, the swap and other unused partitions will be deleted.  If you set this parameter to 0, the maximum amount of space on the device hosting the root filesystem will be used.  If set to integer >0, your root filesystem will be expanding to that size in GB.  Do not append a postfix; even if you do, it will be ignored and the integer value will be interpreted in GB.")
 pc.defineParameter("swiftLVSize", "Swift Logical Volume Size",
                    portal.ParameterType.INTEGER,4,advanced=True,
@@ -205,9 +205,9 @@ pc.defineParameter("keystoneVersion","Keystone API Version",
                    portal.ParameterType.INTEGER,
                    0, [ (0,"(default)"),(2,"v2.0"),(3,"v3") ],advanced=True,
                    longDescription="Keystone API Version.  Defaults to v2.0 on Juno and Kilo; defaults to v3 on Liberty and onwards.  You can try to force v2.0 on Liberty and onwards, but we cannot guarantee support for this configuration.")
-pc.defineParameter("keystoneUseMemcache","Keystone Uses Memcache",
-                   portal.ParameterType.BOOLEAN,False,advanced=True,
-                   longDescription="Specify whether or not Keystone should use Memcache as its token backend.  In our testing, this has seemed to exacerbate intermittent Keystone internal errors, so it is off by default, and by default, the SQL token backend is used instead.")
+# pc.defineParameter("keystoneUseMemcache","Keystone Uses Memcache",
+#                    portal.ParameterType.BOOLEAN,False,advanced=True,
+#                    longDescription="Specify whether or not Keystone should use Memcache as its token backend.  In our testing, this has seemed to exacerbate intermittent Keystone internal errors, so it is off by default, and by default, the SQL token backend is used instead.")
 pc.defineParameter("keystoneUseWSGI","Keystone Uses WSGI",
                    portal.ParameterType.INTEGER,
                    2, [ (2,"(default)"),(1,"Yes"),(0,"No") ],advanced=True,
@@ -236,9 +236,9 @@ pc.defineParameter("enableNewSerialSupport","Enable new Juno serial consoles",
                    portal.ParameterType.BOOLEAN,False,advanced=True,
                    longDescription="Enable new serial console support added in Juno.  This means you can access serial consoles via web sockets from a CLI tool (not in the dashboard yet), but the serial console log will no longer be available for viewing!  Until it supports both interactivity and logging, you will have to choose.  We download software for you and create a simple frontend script on your controller node, /root/setup/novaconsole.sh , that when given the name of an instance as its sole argument, will connect you to its serial console.  The escape sequence is ~. (tilde,period), but make sure to use multiple tildes to escape through your ssh connection(s), so that those are not disconnected along with your console session.")
 
-pc.defineParameter("ceilometerUseMongoDB","Use MongoDB in Ceilometer",
-                   portal.ParameterType.BOOLEAN,False,advanced=True,
-                   longDescription="Use MongoDB for Ceilometer instead of MySQL (with Ubuntu 14 and Juno, we have observed crashy behavior with MongoDB, so the default is MySQL; YMMV.  Also, this option only applies to OpenStack releases < Ocata.")
+# pc.defineParameter("ceilometerUseMongoDB","Use MongoDB in Ceilometer",
+#                    portal.ParameterType.BOOLEAN,False,advanced=True,
+#                    longDescription="Use MongoDB for Ceilometer instead of MySQL (with Ubuntu 14 and Juno, we have observed crashy behavior with MongoDB, so the default is MySQL; YMMV.  Also, this option only applies to OpenStack releases < Ocata.")
 
 pc.defineParameter("enableVerboseLogging","Enable Verbose Logging",
                    portal.ParameterType.BOOLEAN,False,advanced=True,
@@ -378,14 +378,14 @@ if params.fromScratch and not params.doAptInstall:
     perr = portal.ParameterError("You cannot start from a bare image and choose not to install any OpenStack packages!",['fromScratch','doAptInstall'])
     pc.reportError(perr)
     pass
-if params.doAptUpgrade and not params.doAptInstall:
-    perr = portal.ParameterWarning("If you disable package installation, and request package upgrades, nothing will happen; you'll have to comb through the setup script logfiles to see what packages would have been upgraded.",['doAptUpgrade','doAptInstall'])
-    pc.reportWarning(perr)
-    pass
-if params.doAptDistUpgrade and not params.doAptInstall:
-    perr = portal.ParameterWarning("If you disable package installation, and request all packages to be upgraded, nothing will happen; so you need to change your parameter values.",['doAptDistUpgrade','doAptInstall'])
-    pc.reportWarning(perr)
-    pass
+# if params.doAptUpgrade and not params.doAptInstall:
+#     perr = portal.ParameterWarning("If you disable package installation, and request package upgrades, nothing will happen; you'll have to comb through the setup script logfiles to see what packages would have been upgraded.",['doAptUpgrade','doAptInstall'])
+#     pc.reportWarning(perr)
+#     pass
+# if params.doAptDistUpgrade and not params.doAptInstall:
+#     perr = portal.ParameterWarning("If you disable package installation, and request all packages to be upgraded, nothing will happen; so you need to change your parameter values.",['doAptDistUpgrade','doAptInstall'])
+#     pc.reportWarning(perr)
+#     pass
 
 if params.publicIPCount > 16:
     perr = portal.ParameterWarning("You cannot request more than 16 public IP addresses, at least not without creating your own modified version of this profile!",['publicIPCount'])
@@ -1103,12 +1103,12 @@ class Parameters(RSpec.Resource):
 #        param.text = 'STORAGEHOST="%s"' % (params.blockStorageHost,)
         param = ET.SubElement(el,paramXML)
         param.text = 'DO_APT_INSTALL=%d' % (int(params.doAptInstall),)
-        param = ET.SubElement(el,paramXML)
-        param.text = 'DO_APT_UPGRADE=%d' % (int(params.doAptUpgrade),)
-        param = ET.SubElement(el,paramXML)
-        param.text = 'DO_APT_DIST_UPGRADE=%d' % (int(params.doAptDistUpgrade),)
-        param = ET.SubElement(el,paramXML)
-        param.text = 'DO_UBUNTU_CLOUDARCHIVE_STAGING=%d' % (int(params.doCloudArchiveStaging),)
+        # param = ET.SubElement(el,paramXML)
+        # param.text = 'DO_APT_UPGRADE=%d' % (int(params.doAptUpgrade),)
+        # param = ET.SubElement(el,paramXML)
+        # param.text = 'DO_APT_DIST_UPGRADE=%d' % (int(params.doAptDistUpgrade),)
+        # param = ET.SubElement(el,paramXML)
+        # param.text = 'DO_UBUNTU_CLOUDARCHIVE_STAGING=%d' % (int(params.doCloudArchiveStaging),)
         param = ET.SubElement(el,paramXML)
         param.text = 'DO_APT_UPDATE=%d' % (int(params.doAptUpdate),)
 
@@ -1146,8 +1146,8 @@ class Parameters(RSpec.Resource):
         param = ET.SubElement(el,paramXML)
         param.text = "USE_NEUTRON_LBAAS=%d" % (int(params.enableNeutronLoadBalancing))
 
-        param = ET.SubElement(el,paramXML)
-        param.text = "CEILOMETER_USE_MONGODB=%d" % (int(params.ceilometerUseMongoDB))
+        # param = ET.SubElement(el,paramXML)
+        # param.text = "CEILOMETER_USE_MONGODB=%d" % (int(params.ceilometerUseMongoDB))
 
         param = ET.SubElement(el,paramXML)
         param.text = "VERBOSE_LOGGING=\"%s\"" % (str(bool(params.enableVerboseLogging)))
@@ -1164,8 +1164,8 @@ class Parameters(RSpec.Resource):
             param.text = "KEYSTONEAPIVERSION=%d" % (int(params.keystoneVersion))
             pass
 
-        param = ET.SubElement(el,paramXML)
-        param.text = "KEYSTONEUSEMEMCACHE=%d" % (int(bool(params.keystoneUseMemcache)))
+        # param = ET.SubElement(el,paramXML)
+        # param.text = "KEYSTONEUSEMEMCACHE=%d" % (int(bool(params.keystoneUseMemcache)))
 
         if params.keystoneUseWSGI == 0:
             param = ET.SubElement(el,paramXML)
@@ -1179,13 +1179,13 @@ class Parameters(RSpec.Resource):
         param = ET.SubElement(el,paramXML)
         param.text = "QUOTASOFF=%d" % (int(bool(params.quotasOff)))
 
-        if params.ubuntuMirrorHost != "":
-            param = ET.SubElement(el,paramXML)
-            param.text = "UBUNTUMIRRORHOST=\"%s\"" % (params.ubuntuMirrorHost,)
-        if params.ubuntuMirrorPath != "":
-            param = ET.SubElement(el,paramXML)
-            param.text = "UBUNTUMIRRORPATH=\"%s\"" % (params.ubuntuMirrorPath,)
-            pass
+        # if params.ubuntuMirrorHost != "":
+        #     param = ET.SubElement(el,paramXML)
+        #     param.text = "UBUNTUMIRRORHOST=\"%s\"" % (params.ubuntuMirrorHost,)
+        # if params.ubuntuMirrorPath != "":
+        #     param = ET.SubElement(el,paramXML)
+        #     param.text = "UBUNTUMIRRORPATH=\"%s\"" % (params.ubuntuMirrorPath,)
+        #     pass
 
         param = ET.SubElement(el,paramXML)
         param.text = "ML2PLUGIN=%s" % (str(params.ml2plugin))
@@ -1193,8 +1193,8 @@ class Parameters(RSpec.Resource):
         param = ET.SubElement(el,paramXML)
         param.text = "USE_DESIGNATE_AS_RESOLVER=%d" % (int(bool(params.useDesignateAsResolver)))
 
-        param = ET.SubElement(el,paramXML)
-        param.text = "EXTRAIMAGEURLS='%s'" % (str(params.extraImageURLs))
+        # param = ET.SubElement(el,paramXML)
+        # param.text = "EXTRAIMAGEURLS='%s'" % (str(params.extraImageURLs))
 
         param = ET.SubElement(el,paramXML)
         param.text = "OSRELEASE='%s'" % (str(params.release))

--- a/setup-pythia-compute.sh
+++ b/setup-pythia-compute.sh
@@ -3,7 +3,6 @@
 set -x
 
 DIRNAME=`dirname $0`
-CURUSR=`whoami`
 
 # Gotta know the rules!
 if [ $EUID -ne 0 ] ; then
@@ -65,7 +64,9 @@ do
     cd /local
 done
 
-# Directly clone pythia repo instead since reconstruction repo in disk image might not be working. 
+# Remove reconstruction repo & clone new pythia repo
+echo "y" | rm -r /local/reconstruction/
+echo "y" | rm -i /users/geniuser/reconstruction
 git clone https://github.com/docc-lab/pythia.git
 
 mkdir -p /opt/stack/manifest
@@ -77,20 +78,20 @@ service_start redis
 maybe_install_packages python3-pip
 
 # Bring back rustup for compilation error
-su $CURUSR -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
+su geniuser -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
 source $HOME/.cargo/env
 rustup update stable
 echo "**** Mert updating rust for match compile error ***"
 
 
-chown $CURUSR -R /local/pythia
-su $CURUSR -c "cargo update --manifest-path /local/pythia/Cargo.toml -p lexical-core"
-su $CURUSR -c "cargo update --manifest-path /local/pythia/pythia_server/Cargo.toml -p lexical-core"
-su $CURUSR -c "cargo install --locked --path /local/pythia"
-su $CURUSR -c "cargo install --locked --path /local/pythia/pythia_server"
-sudo ln -s /users/$CURUSR/.cargo/bin/pythia_server /usr/local/bin/
-sudo ln -s /local/pythia /users/$CURUSR/
-sudo ln -s /local/dotfiles /users/$CURUSR/
+chown geniuser -R /local/pythia
+su geniuser -c "cargo update --manifest-path /local/pythia/Cargo.toml -p lexical-core"
+su geniuser -c "cargo update --manifest-path /local/pythia/pythia_server/Cargo.toml -p lexical-core"
+su geniuser -c "cargo install --locked --path /local/pythia"
+su geniuser -c "cargo install --locked --path /local/pythia/pythia_server"
+sudo ln -s /users/geniuser/.cargo/bin/pythia_server /usr/local/bin/
+sudo ln -s /local/pythia /users/geniuser/
+sudo ln -s /local/dotfiles /users/geniuser/
 
 echo -e 'nova\tALL=(ALL)\tNOPASSWD: ALL' >> /etc/sudoers
 
@@ -143,7 +144,7 @@ sudo systemctl start pythia.service
 touch $OURDIR/setup-pythia-compute-done
 logtend "pythia-compute"
 
-chown $CURUSR -R /local
-su $CURUSR -c 'cd /local/dotfiles; ./setup_cloudlab.sh'
+chown geniuser -R /local
+su geniuser -c 'cd /local/dotfiles; ./setup_cloudlab.sh'
 
 exit 0

--- a/setup-pythia-compute.sh
+++ b/setup-pythia-compute.sh
@@ -3,7 +3,6 @@
 set -x
 
 DIRNAME=`dirname $0`
-CURUSR=`whoami`
 
 # Gotta know the rules!
 if [ $EUID -ne 0 ] ; then

--- a/setup-pythia-compute.sh
+++ b/setup-pythia-compute.sh
@@ -88,8 +88,7 @@ su toslali -c "cargo update --manifest-path /local/pythia/pythia_server/Cargo.to
 su toslali -c "cargo install --locked --path /local/pythia"
 su toslali -c "cargo install --locked --path /local/pythia/pythia_server"
 sudo ln -s /users/toslali/.cargo/bin/pythia_server /usr/local/bin/
-sudo mkdir /users/toslali/pythia
-sudo ln -s /local/pythia /users/toslali/pythia
+sudo ln -s /local/pythia /users/toslali/
 
 echo -e 'nova\tALL=(ALL)\tNOPASSWD: ALL' >> /etc/sudoers
 

--- a/setup-pythia-compute.sh
+++ b/setup-pythia-compute.sh
@@ -76,19 +76,19 @@ service_start redis
 maybe_install_packages python3-pip
 
 # Bring back rustup for compilation error
-su toslali -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
+su $CURUSR -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
 source $HOME/.cargo/env
 rustup update stable
 echo "**** Mert updating rust for match compile error ***"
 
 
-chown toslali -R /local/pythia
-su toslali -c "cargo update --manifest-path /local/pythia/Cargo.toml -p lexical-core"
-su toslali -c "cargo update --manifest-path /local/pythia/pythia_server/Cargo.toml -p lexical-core"
-su toslali -c "cargo install --locked --path /local/pythia"
-su toslali -c "cargo install --locked --path /local/pythia/pythia_server"
-sudo ln -s /users/toslali/.cargo/bin/pythia_server /usr/local/bin/
-sudo ln -s /local/pythia /users/toslali/
+chown $CURUSR -R /local/pythia
+su $CURUSR -c "cargo update --manifest-path /local/pythia/Cargo.toml -p lexical-core"
+su $CURUSR -c "cargo update --manifest-path /local/pythia/pythia_server/Cargo.toml -p lexical-core"
+su $CURUSR -c "cargo install --locked --path /local/pythia"
+su $CURUSR -c "cargo install --locked --path /local/pythia/pythia_server"
+sudo ln -s /users/$CURUSR/.cargo/bin/pythia_server /usr/local/bin/
+sudo ln -s /local/pythia /users/$CURUSR/
 
 echo -e 'nova\tALL=(ALL)\tNOPASSWD: ALL' >> /etc/sudoers
 
@@ -141,7 +141,7 @@ sudo systemctl start pythia.service
 touch $OURDIR/setup-pythia-compute-done
 logtend "pythia-compute"
 
-chown toslali -R /local
-su toslali -c 'cd /local/dotfiles; ./setup_cloudlab.sh'
+chown $CURUSR -R /local
+su $CURUSR -c 'cd /local/dotfiles; ./setup_cloudlab.sh'
 
 exit 0

--- a/setup-pythia-compute.sh
+++ b/setup-pythia-compute.sh
@@ -66,7 +66,7 @@ done
 
 # Remove reconstruction repo & clone new pythia repo
 echo "y" | rm -r /local/reconstruction/
-echo "y" | rm -i /users/geniuser/reconstruction
+sudo echo "y" | rm -i /users/geniuser/reconstruction
 git clone https://github.com/docc-lab/pythia.git
 
 mkdir -p /opt/stack/manifest
@@ -146,5 +146,7 @@ logtend "pythia-compute"
 
 chown geniuser -R /local
 su geniuser -c 'cd /local/dotfiles; ./setup_cloudlab.sh'
+
+sudo chsh geniuser --shell /bin/bash
 
 exit 0

--- a/setup-pythia-compute.sh
+++ b/setup-pythia-compute.sh
@@ -3,6 +3,7 @@
 set -x
 
 DIRNAME=`dirname $0`
+CURUSR=`whoami`
 
 # Gotta know the rules!
 if [ $EUID -ne 0 ] ; then

--- a/setup-pythia-compute.sh
+++ b/setup-pythia-compute.sh
@@ -3,6 +3,7 @@
 set -x
 
 DIRNAME=`dirname $0`
+CURUSR=`whoami`
 
 # Gotta know the rules!
 if [ $EUID -ne 0 ] ; then
@@ -89,6 +90,7 @@ su $CURUSR -c "cargo install --locked --path /local/pythia"
 su $CURUSR -c "cargo install --locked --path /local/pythia/pythia_server"
 sudo ln -s /users/$CURUSR/.cargo/bin/pythia_server /usr/local/bin/
 sudo ln -s /local/pythia /users/$CURUSR/
+sudo ln -s /local/dotfiles /users/$CURUSR/
 
 echo -e 'nova\tALL=(ALL)\tNOPASSWD: ALL' >> /etc/sudoers
 

--- a/setup-pythia.sh
+++ b/setup-pythia.sh
@@ -3,7 +3,6 @@
 set -x
 
 DIRNAME=`dirname $0`
-CURUSR=`whoami`
 
 # Gotta know the rules!
 if [ $EUID -ne 0 ] ; then
@@ -68,7 +67,9 @@ do
     cd /local
 done
 
-# Reconstruction repo in disk image might not be working. Directly clone pythia repo instead.
+# Remove reconstruction repo & clone new pythia repo
+echo "y" | rm -r /local/reconstruction/
+echo "y" | rm -i /users/geniuser/reconstruction
 git clone https://github.com/docc-lab/pythia.git
 
 PHOSTS=""
@@ -87,21 +88,21 @@ maybe_install_packages python3-pip
 
 # Bring back rustup for compilation error
 
-su $CURUSR -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
+su geniuser -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
 
 source $HOME/.cargo/env
 rustup update stable
 echo "**** Mert updating rust for match compile error ***"
 
 
-chown $CURUSR -R /local/pythia
-su $CURUSR -c "cargo update --manifest-path /local/pythia/Cargo.toml -p lexical-core"
-su $CURUSR -c "cargo update --manifest-path /local/pythia/pythia_server/Cargo.toml -p lexical-core"
-su $CURUSR -c "cargo install --locked --path /local/pythia"
-su $CURUSR -c "cargo install --locked --path /local/pythia/pythia_server"
-sudo ln -s /users/$CURUSR/.cargo/bin/pythia_server /usr/local/bin/
-sudo ln -s /local/pythia /users/$CURUSR/
-sudo ln -s /local/dotfiles /users/$CURUSR/
+chown geniuser -R /local/pythia
+su geniuser -c "cargo update --manifest-path /local/pythia/Cargo.toml -p lexical-core"
+su geniuser -c "cargo update --manifest-path /local/pythia/pythia_server/Cargo.toml -p lexical-core"
+su geniuser -c "cargo install --locked --path /local/pythia"
+su geniuser -c "cargo install --locked --path /local/pythia/pythia_server"
+sudo ln -s /users/geniuser/.cargo/bin/pythia_server /usr/local/bin/
+sudo ln -s /local/pythia /users/geniuser/
+sudo ln -s /local/dotfiles /users/geniuser/
 
 mkdir -p /opt/stack/manifest
 chmod -R g+rwX /opt/
@@ -218,7 +219,7 @@ sudo systemctl start pythia.service
 touch $OURDIR/setup-pythia-done
 logtend "pythia"
 
-chown $CURUSR -R /local
-su $CURUSR -c 'cd /local/dotfiles; ./setup_cloudlab.sh'
+chown geniuser -R /local
+su geniuser -c 'cd /local/dotfiles; ./setup_cloudlab.sh'
 
 exit 0

--- a/setup-pythia.sh
+++ b/setup-pythia.sh
@@ -100,7 +100,7 @@ su $CURUSR -c "cargo update --manifest-path /local/pythia/pythia_server/Cargo.to
 su $CURUSR -c "cargo install --locked --path /local/pythia"
 su $CURUSR -c "cargo install --locked --path /local/pythia/pythia_server"
 sudo ln -s /users/$CURUSR/.cargo/bin/pythia_server /usr/local/bin/
-sudo ln -s /local/pythia /users/$CURUSR
+sudo ln -s /local/pythia /users/$CURUSR/
 sudo ln -s /local/dotfiles /users/$CURUSR/
 
 mkdir -p /opt/stack/manifest

--- a/setup-pythia.sh
+++ b/setup-pythia.sh
@@ -208,6 +208,8 @@ sudo ln -s /local/pythia/etc/pythia /etc/
 chmod -R g+rwX /etc/pythia
 chmod -R o+rwX /etc/pythia
 
+chmod -R 777 /local/reconstruction/workloads
+
 sudo systemctl start pythia.service
 
 touch $OURDIR/setup-pythia-done

--- a/setup-pythia.sh
+++ b/setup-pythia.sh
@@ -99,6 +99,8 @@ su toslali -c "cargo update --manifest-path /local/pythia/pythia_server/Cargo.to
 su toslali -c "cargo install --locked --path /local/pythia"
 su toslali -c "cargo install --locked --path /local/pythia/pythia_server"
 sudo ln -s /users/toslali/.cargo/bin/pythia_server /usr/local/bin/
+sudo mkdir /users/toslali/pythia
+sudo ln -s /local/pythia /users/toslali/pythia
 
 mkdir -p /opt/stack/manifest
 chmod -R g+rwX /opt/
@@ -208,7 +210,7 @@ sudo ln -s /local/pythia/etc/pythia /etc/
 chmod -R g+rwX /etc/pythia
 chmod -R o+rwX /etc/pythia
 
-chmod -R 777 /local/reconstruction/workloads
+chmod -R 777 /local/pythia/workloads
 
 sudo systemctl start pythia.service
 

--- a/setup-pythia.sh
+++ b/setup-pythia.sh
@@ -3,6 +3,7 @@
 set -x
 
 DIRNAME=`dirname $0`
+CURUSR=`whoami`
 
 # Gotta know the rules!
 if [ $EUID -ne 0 ] ; then
@@ -86,20 +87,20 @@ maybe_install_packages python3-pip
 
 # Bring back rustup for compilation error
 
-su toslali -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
+su $CURUSR -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
 
 source $HOME/.cargo/env
 rustup update stable
 echo "**** Mert updating rust for match compile error ***"
 
 
-chown toslali -R /local/pythia
-su toslali -c "cargo update --manifest-path /local/pythia/Cargo.toml -p lexical-core"
-su toslali -c "cargo update --manifest-path /local/pythia/pythia_server/Cargo.toml -p lexical-core"
-su toslali -c "cargo install --locked --path /local/pythia"
-su toslali -c "cargo install --locked --path /local/pythia/pythia_server"
-sudo ln -s /users/toslali/.cargo/bin/pythia_server /usr/local/bin/
-sudo ln -s /local/pythia /users/toslali
+chown $CURUSR -R /local/pythia
+su $CURUSR -c "cargo update --manifest-path /local/pythia/Cargo.toml -p lexical-core"
+su $CURUSR -c "cargo update --manifest-path /local/pythia/pythia_server/Cargo.toml -p lexical-core"
+su $CURUSR -c "cargo install --locked --path /local/pythia"
+su $CURUSR -c "cargo install --locked --path /local/pythia/pythia_server"
+sudo ln -s /users/$CURUSR/.cargo/bin/pythia_server /usr/local/bin/
+sudo ln -s /local/pythia /users/$CURUSR
 
 mkdir -p /opt/stack/manifest
 chmod -R g+rwX /opt/
@@ -216,7 +217,7 @@ sudo systemctl start pythia.service
 touch $OURDIR/setup-pythia-done
 logtend "pythia"
 
-chown toslali -R /local
-su toslali -c 'cd /local/dotfiles; ./setup_cloudlab.sh'
+chown $CURUSR -R /local
+su $CURUSR -c 'cd /local/dotfiles; ./setup_cloudlab.sh'
 
 exit 0

--- a/setup-pythia.sh
+++ b/setup-pythia.sh
@@ -69,7 +69,7 @@ done
 
 # Remove reconstruction repo & clone new pythia repo
 echo "y" | rm -r /local/reconstruction/
-echo "y" | rm -i /users/geniuser/reconstruction
+sudo echo "y" | rm -i /users/geniuser/reconstruction
 git clone https://github.com/docc-lab/pythia.git
 
 PHOSTS=""
@@ -221,5 +221,7 @@ logtend "pythia"
 
 chown geniuser -R /local
 su geniuser -c 'cd /local/dotfiles; ./setup_cloudlab.sh'
+
+sudo chsh geniuser --shell /bin/bash
 
 exit 0

--- a/setup-pythia.sh
+++ b/setup-pythia.sh
@@ -55,14 +55,20 @@ PSCP='/usr/bin/parallel-scp -t 0 -O StrictHostKeyChecking=no '
 cd /local
 
 # Update repositories
-for repo in "dotfiles" "nova" "neutron" "osc_lib" "oslo.messaging" "osprofiler" "python-openstackclient" "reconstruction" "oslo.log" "python-novaclient"
+for repo in "dotfiles" "nova" "neutron" "osc_lib" "oslo.messaging" "osprofiler" "python-openstackclient" "oslo.log" "python-novaclient"
 do
     cd /local/$repo
-    GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i /local/.ssh/$repo" git fetch --all
+    # no key needed for public repos
+    # GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i /local/.ssh/$repo" git fetch --all
+    git fetch -all
     git checkout $(git status | head -n 1 | awk '{print $3}') -f
-    GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i /local/.ssh/$repo" git pull
+    # GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i /local/.ssh/$repo" git pull
+    git pull
     cd /local
 done
+
+# Reconstruction repo in disk image might not be working. Directly clone pythia repo instead.
+git clone https://github.com/docc-lab/pythia.git
 
 PHOSTS=""
 mkdir -p $OURDIR/pssh.setup-pythia.stdout $OURDIR/pssh.setup-pythia.stderr
@@ -87,11 +93,11 @@ rustup update stable
 echo "**** Mert updating rust for match compile error ***"
 
 
-chown toslali -R /local/reconstruction
-su toslali -c "cargo update --manifest-path /local/reconstruction/Cargo.toml -p lexical-core"
-su toslali -c "cargo update --manifest-path /local/reconstruction/pythia_server/Cargo.toml -p lexical-core"
-su toslali -c "cargo install --locked --path /local/reconstruction"
-su toslali -c "cargo install --locked --path /local/reconstruction/pythia_server"
+chown toslali -R /local/pythia
+su toslali -c "cargo update --manifest-path /local/pythia/Cargo.toml -p lexical-core"
+su toslali -c "cargo update --manifest-path /local/pythia/pythia_server/Cargo.toml -p lexical-core"
+su toslali -c "cargo install --locked --path /local/pythia"
+su toslali -c "cargo install --locked --path /local/pythia/pythia_server"
 sudo ln -s /users/toslali/.cargo/bin/pythia_server /usr/local/bin/
 
 mkdir -p /opt/stack/manifest
@@ -197,8 +203,8 @@ sudo chronyc -a 'burst 4/4'
 wget https://download.cirros-cloud.net/0.5.1/cirros-0.5.1-${ARCH}-disk.img
 openstack image create --file cirros-0.5.1-${ARCH}-disk.img cirros
 
-sudo ln -s /local/reconstruction/etc/systemd/system/pythia.service /etc/systemd/system/
-sudo ln -s /local/reconstruction/etc/pythia /etc/
+sudo ln -s /local/pythia/etc/systemd/system/pythia.service /etc/systemd/system/
+sudo ln -s /local/pythia/etc/pythia /etc/
 chmod -R g+rwX /etc/pythia
 chmod -R o+rwX /etc/pythia
 

--- a/setup-pythia.sh
+++ b/setup-pythia.sh
@@ -101,6 +101,7 @@ su $CURUSR -c "cargo install --locked --path /local/pythia"
 su $CURUSR -c "cargo install --locked --path /local/pythia/pythia_server"
 sudo ln -s /users/$CURUSR/.cargo/bin/pythia_server /usr/local/bin/
 sudo ln -s /local/pythia /users/$CURUSR
+sudo ln -s /local/dotfiles /users/$CURUSR/
 
 mkdir -p /opt/stack/manifest
 chmod -R g+rwX /opt/

--- a/setup-pythia.sh
+++ b/setup-pythia.sh
@@ -99,8 +99,7 @@ su toslali -c "cargo update --manifest-path /local/pythia/pythia_server/Cargo.to
 su toslali -c "cargo install --locked --path /local/pythia"
 su toslali -c "cargo install --locked --path /local/pythia/pythia_server"
 sudo ln -s /users/toslali/.cargo/bin/pythia_server /usr/local/bin/
-sudo mkdir /users/toslali/pythia
-sudo ln -s /local/pythia /users/toslali/pythia
+sudo ln -s /local/pythia /users/toslali
 
 mkdir -p /opt/stack/manifest
 chmod -R g+rwX /opt/


### PR DESCRIPTION
List of things done:

1. Get rid of any permission dependency that is related to a specific cloudlab organization.

    - There are several options as we discussed: a. create a dummy user, b. change to the current user of the setting-up script.
    - But I found an easier way--to make use of an existing dummy user provided by cloudlab in every project, called `geniuser`
 
3. Remove old reconstruction repo and symbolic links
4. Add necessary symbolic links for `geniuser`


Code review & testing:
- Please check [this experiment under our cloudlab org](https://www.cloudlab.us/status.php?uuid=864e8552-5a67-11ed-b318-e4434b2381fc) that uses this branch.
- I have another experiment instantiated with this branch under another cloudlab org that might not be accessible to others. I can demo it during Friday's meeting.