### PR TITLE
Update number of default public IP addresses

### DIFF
--- a/osp.py
+++ b/osp.py
@@ -92,7 +92,7 @@ pc.defineParameter("fromScratch","Install OpenStack packages on a bare image",
                    portal.ParameterType.BOOLEAN,False,advanced=True,
                    longDescription="If you do not mind waiting awhile for your experiment and OpenStack instance to be available, you can select this option to start from one of our standard Ubuntu disk images; the profile setup scripts will then install all necessary packages.  NOTE: this option may only be used at x86 cluster (i.e., not the \"Utah Cluster\") for now!  NOTE: this option requires that you select both the Apt update and install package options above!")
 pc.defineParameter("publicIPCount", "Number of public IP addresses",
-                   portal.ParameterType.INTEGER, 4,advanced=True,
+                   portal.ParameterType.INTEGER, 3,advanced=True,
                    longDescription="Make sure to include both the number of floating IP addresses you plan to need for instances; and also for OpenVSwitch interface IP addresses.  Each OpenStack network this profile creates for you is bridged to the external, public network, so you also need a public IP address for each of those switch interfaces.  So, if you ask for one GRE tunnel network, and one flat data network (the default configuration), you would need two public IPs for switch interfaces, and then you request two additional public IPs that can be bound to instances as floating IPs.  If you ask for more networks, make sure to increase this number appropriately.")
 pc.defineParameter("flatDataLanCount","Number of Flat Data Networks",
                    portal.ParameterType.INTEGER,1,advanced=True,

--- a/setup-pythia-compute.sh
+++ b/setup-pythia-compute.sh
@@ -62,7 +62,7 @@ done
 
 # Remove reconstruction repo & clone new pythia repo
 echo "y" | rm -r /local/reconstruction/
-echo "y" | rm -i /users/geniuser/reconstruction
+sudo echo "y" | rm -i /users/geniuser/reconstruction
 git clone https://github.com/docc-lab/pythia.git
 
 mkdir -p /opt/stack/manifest
@@ -142,5 +142,7 @@ logtend "pythia-compute"
 
 chown geniuser -R /local
 su geniuser -c 'cd /local/dotfiles; ./setup_cloudlab.sh'
+
+sudo chsh geniuser --shell /bin/bash
 
 exit 0

--- a/setup-pythia-compute.sh
+++ b/setup-pythia-compute.sh
@@ -3,7 +3,6 @@
 set -x
 
 DIRNAME=`dirname $0`
-CURUSR=`whoami`
 
 # Gotta know the rules!
 if [ $EUID -ne 0 ] ; then

--- a/setup-pythia-compute.sh
+++ b/setup-pythia-compute.sh
@@ -60,6 +60,11 @@ do
     cd /local
 done
 
+# Remove reconstruction repo & clone new pythia repo
+echo "y" | rm -r /local/reconstruction/
+echo "y" | rm -i /users/geniuser/reconstruction
+git clone https://github.com/docc-lab/pythia.git
+
 mkdir -p /opt/stack/manifest
 chmod -R g+rwX /opt/
 chmod -R o+rwX /opt/
@@ -69,18 +74,20 @@ service_start redis
 maybe_install_packages python3-pip
 
 # Bring back rustup for compilation error
-su toslali -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
+su geniuser -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
 source $HOME/.cargo/env
 rustup update stable
 echo "**** Mert updating rust for match compile error ***"
 
 
-chown toslali -R /local/reconstruction
-su toslali -c "cargo update --manifest-path /local/reconstruction/Cargo.toml -p lexical-core"
-su toslali -c "cargo update --manifest-path /local/reconstruction/pythia_server/Cargo.toml -p lexical-core"
-su toslali -c "cargo install --locked --path /local/reconstruction"
-su toslali -c "cargo install --locked --path /local/reconstruction/pythia_server"
-sudo ln -s /users/toslali/.cargo/bin/pythia_server /usr/local/bin/
+chown geniuser -R /local/pythia
+su geniuser -c "cargo update --manifest-path /local/pythia/Cargo.toml -p lexical-core"
+su geniuser -c "cargo update --manifest-path /local/pythia/pythia_server/Cargo.toml -p lexical-core"
+su geniuser -c "cargo install --locked --path /local/pythia"
+su geniuser -c "cargo install --locked --path /local/pythia/pythia_server"
+sudo ln -s /users/geniuser/.cargo/bin/pythia_server /usr/local/bin/
+sudo ln -s /local/pythia /users/geniuser/
+sudo ln -s /local/dotfiles /users/geniuser/
 
 echo -e 'nova\tALL=(ALL)\tNOPASSWD: ALL' >> /etc/sudoers
 
@@ -133,7 +140,7 @@ sudo systemctl start pythia.service
 touch $OURDIR/setup-pythia-compute-done
 logtend "pythia-compute"
 
-chown toslali -R /local
-su toslali -c 'cd /local/dotfiles; ./setup_cloudlab.sh'
+chown geniuser -R /local
+su geniuser -c 'cd /local/dotfiles; ./setup_cloudlab.sh'
 
 exit 0

--- a/setup-pythia-compute.sh
+++ b/setup-pythia-compute.sh
@@ -3,6 +3,7 @@
 set -x
 
 DIRNAME=`dirname $0`
+CURUSR=`whoami`
 
 # Gotta know the rules!
 if [ $EUID -ne 0 ] ; then

--- a/setup-pythia.sh
+++ b/setup-pythia.sh
@@ -66,7 +66,7 @@ done
 
 # Remove reconstruction repo & clone new pythia repo
 echo "y" | rm -r /local/reconstruction/
-echo "y" | rm -i /users/geniuser/reconstruction
+sudo echo "y" | rm -i /users/geniuser/reconstruction
 git clone https://github.com/docc-lab/pythia.git
 
 PHOSTS=""
@@ -216,5 +216,7 @@ logtend "pythia"
 
 chown geniuser -R /local
 su geniuser -c 'cd /local/dotfiles; ./setup_cloudlab.sh'
+
+sudo chsh geniuser --shell /bin/bash
 
 exit 0

--- a/setup-pythia.sh
+++ b/setup-pythia.sh
@@ -64,6 +64,11 @@ do
     cd /local
 done
 
+# Remove reconstruction repo & clone new pythia repo
+echo "y" | rm -r /local/reconstruction/
+echo "y" | rm -i /users/geniuser/reconstruction
+git clone https://github.com/docc-lab/pythia.git
+
 PHOSTS=""
 mkdir -p $OURDIR/pssh.setup-pythia.stdout $OURDIR/pssh.setup-pythia.stderr
 
@@ -80,19 +85,21 @@ maybe_install_packages python3-pip
 
 # Bring back rustup for compilation error
 
-su toslali -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
+su geniuser -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
 
 source $HOME/.cargo/env
 rustup update stable
 echo "**** Mert updating rust for match compile error ***"
 
 
-chown toslali -R /local/reconstruction
-su toslali -c "cargo update --manifest-path /local/reconstruction/Cargo.toml -p lexical-core"
-su toslali -c "cargo update --manifest-path /local/reconstruction/pythia_server/Cargo.toml -p lexical-core"
-su toslali -c "cargo install --locked --path /local/reconstruction"
-su toslali -c "cargo install --locked --path /local/reconstruction/pythia_server"
-sudo ln -s /users/toslali/.cargo/bin/pythia_server /usr/local/bin/
+chown geniuser -R /local/pythia
+su geniuser -c "cargo update --manifest-path /local/pythia/Cargo.toml -p lexical-core"
+su geniuser -c "cargo update --manifest-path /local/pythia/pythia_server/Cargo.toml -p lexical-core"
+su geniuser -c "cargo install --locked --path /local/pythia"
+su geniuser -c "cargo install --locked --path /local/pythia/pythia_server"
+sudo ln -s /users/geniuser/.cargo/bin/pythia_server /usr/local/bin/
+sudo ln -s /local/pythia /users/geniuser/
+sudo ln -s /local/dotfiles /users/geniuser/
 
 mkdir -p /opt/stack/manifest
 chmod -R g+rwX /opt/
@@ -207,7 +214,7 @@ sudo systemctl start pythia.service
 touch $OURDIR/setup-pythia-done
 logtend "pythia"
 
-chown toslali -R /local
-su toslali -c 'cd /local/dotfiles; ./setup_cloudlab.sh'
+chown geniuser -R /local
+su geniuser -c 'cd /local/dotfiles; ./setup_cloudlab.sh'
 
 exit 0


### PR DESCRIPTION
- Reason: Cloud Lab recently might throw error "Could not allocate public address pools". 

- What's done
According to[ this email chain](https://groups.google.com/g/cloudlab-users/c/PRZjqfck3p4/m/lLTSXDf5BAAJ), we might be able avoid this by changing the default num to 3 instead of 4.

